### PR TITLE
1 setup local dev env

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -17,14 +17,17 @@ jobs:
       - name: Determine Version
         id: versioning
         run: |
-          if [[ "${{ github.event.pull_request.labels.*.name }}" == "breaking-changes" ]]; then
+          labels=$(echo "${{ toJson(github.event.pull_request.labels) }}" | jq -r '.[].name')
+          bump=""
+
+          if echo "$labels" | grep -q 'breaking-changes'; then
             bump="major"
-          elif [[ "${{ github.event.pull_request.labels.*.name }}" == "feature" ]]; then
+          elif echo "$labels" | grep -q 'feature'; then
             bump="minor"
-          elif [[ "${{ github.event.pull_request.labels.*.name }}" == "bugfix" ]]; then
+          elif echo "$labels" | grep -q 'bugfix'; then
             bump="patch"
           else
-            echo "No version bump found"
+            echo "No valid label found for version bump."
             exit 1
           fi
 

--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -17,11 +17,11 @@ jobs:
       - name: Determine Version
         id: versioning
         run: |
-          if [[ "${{ github.event.pull_request.labels.*.name }}" == *breaking-changes* ]]; then
+          if [[ "${{ github.event.pull_request.labels.*.name }}" == "breaking-changes" ]]; then
             bump="major"
-          elif [[ "${{ github.event.pull_request.labels.*.name }}" == *feature* ]]; then
+          elif [[ "${{ github.event.pull_request.labels.*.name }}" == "feature" ]]; then
             bump="minor"
-          elif [[ "${{ github.event.pull_request.labels.*.name }}" == *bugfix* ]]; then
+          elif [[ "${{ github.event.pull_request.labels.*.name }}" == "bugfix" ]]; then
             bump="patch"
           else
             echo "No version bump found"


### PR DESCRIPTION
This pull request includes a significant change to the version determination logic in the `.github/workflows/dev_build-and-push.yaml` file. The update replaces the previous method of checking pull request labels with a more robust approach using `jq` to parse JSON.

Changes to version determination logic:

* [`.github/workflows/dev_build-and-push.yaml`](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L20-R30): Updated the script to parse pull request labels using `jq` and determine the version bump based on the presence of specific labels ('breaking-changes', 'feature', 'bugfix'). This change improves the reliability of the version bump detection process.