### PR TITLE
Fix dev_build-and-push.yaml

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -30,13 +30,17 @@ jobs:
           labels=$(echo "${{ toJson(github.event.pull_request.labels) }}" | jq -r '.[].name')
           bump=""
 
-          if echo "$labels" | grep -q 'breaking-changes'; then
-            bump="major"
-          elif echo "$labels" | grep -q 'feature'; then
-            bump="minor"
-          elif echo "$labels" | grep -q 'bugfix'; then
-            bump="patch"
-          else
+          for label in $labels; do
+            if [[ "$label" == "breaking-changes" ]]; then
+              bump="major"
+            elif [[ "$label" == "feature" ]]; then
+              bump="minor"
+            elif [[ "$label" == "bugfix" ]]; then
+              bump="patch"
+            fi
+          done
+
+          if [[ -z "$bump" ]]; then
             echo "No valid label found for version bump."
             exit 1
           fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,3 +59,7 @@ Versioning strategie:
     - **MINOR** is incremented for new features without breaking changes.
     - **MAJOR** is incremented manually for breaking changes.
   - Automatic incrementation via labels on PRs into `dev`.
+  - Only one of the following labels can be set at a time:
+    - `breaking-changes`
+    - `feature`
+    - `bugfix`


### PR DESCRIPTION
This pull request includes changes to improve the version bumping process in the GitHub Actions workflow and update the documentation accordingly. The most important changes include modifying the workflow script to use a loop for label checking and updating the documentation to clarify the versioning strategy.

Improvements to version bumping process:

* [`.github/workflows/dev_build-and-push.yaml`](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L33-R43): Changed the script to use a loop for checking labels and determining the version bump type. This ensures that only one label is processed at a time, improving the accuracy of the version bump.

Documentation updates:

* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R62-R65): Updated the versioning strategy section to specify that only one of the labels `breaking-changes`, `feature`, or `bugfix` can be set at a time. This clarification helps maintain consistency in the versioning process.