### PR TITLE
Fix dev_build-and-push.yaml, fetch labels via GH-API

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -14,13 +14,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up GitHub CLI
+        uses: actions/setup-gh-cli@v2
+
+      - name: Authenticate GH
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
       - name: Determine Version
         id: versioning
         run: |
-          raw_labels='${{ github.event.pull_request.labels }}'
-          echo "Raw labels: $raw_labels"
+          pr_number=${{ github.event.pull_request.number }}
       
-          labels=$(echo "$raw_labels" | jq -r '.[].name' 2>/dev/null || true)
+          labels_json=$(gh api \
+          repos/${{ github.repository }}/issues/$pr_number/labels \
+          --jq '.')
+      
+          echo "Labels JSON from GH API: $labels_json"
+      
+          labels=$(echo "$labels_json" | jq -r '.[].name')
       
           if [ -z "$labels" ]; then
             echo "No labels or not JSON parseable."


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow file `.github/workflows/dev_build-and-push.yaml` to enhance the process of determining the version from pull request labels. The most important changes include setting up and authenticating the GitHub CLI, and modifying the method used to fetch and parse labels from a pull request.

Enhancements to GitHub Actions workflow:

* Added steps to set up and authenticate the GitHub CLI using `actions/setup-gh-cli@v2` and the GitHub token.
* Changed the method for determining the version by fetching labels using the GitHub CLI and parsing the JSON response.