### PR TITLE
Fix dev_build-and-push.yaml, fetch labels via GH-API

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -14,9 +14,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up GitHub CLI
-        uses: actions/setup-gh-cli@v2
-
       - name: Authenticate GH
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/dev_build-and-push.yaml` file. The change removes the setup step for the GitHub CLI, which is no longer necessary. 

* [`.github/workflows/dev_build-and-push.yaml`](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L17-L19): Removed the step that sets up the GitHub CLI.