### PR TITLE
ref #1 fix dev_build-and-push.yaml, ref pom at git add

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -56,7 +56,7 @@ jobs:
           echo "next_version=$next_version" >> $GITHUB_ENV
 
       - name: Update Maven Version
-        run: mvn versions:set -DnewVersion=$next_version -f server/pom.xml
+        run: mvn -ntp versions:set -DnewVersion=$next_version -f server/pom.xml
 
       - name: Commit and Push Updated pom.xml
         run: |
@@ -64,7 +64,7 @@ jobs:
           git checkout dev
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git add pom.xml
+          git add server/pom.xml
           git commit -m "Set version to $next_version for PR #${{ github.event.pull_request.number }}"
           git push origin dev
 


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/dev_build-and-push.yaml` file to improve the Maven command and ensure the correct file is added to the commit.

Changes to build and push workflow:

* [`.github/workflows/dev_build-and-push.yaml`](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L59-R67): Added the `-ntp` flag to the Maven command to disable Maven transfer progress, and corrected the path to `pom.xml` in the `git add` command to `server/pom.xml`.