### PR TITLE
ref #1 fix typo

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: server/docker/Dockerfile
+          file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/dev_build-and-push.yaml` file. The change updates the path to the Dockerfile used in the build process.

* [`.github/workflows/dev_build-and-push.yaml`](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L91-R91): Changed the path of the Dockerfile from `server/docker/Dockerfile` to `docker/Dockerfile`.