### PR TITLE
Add skip tests to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.9.9-eclipse-temurin-23 AS build
 WORKDIR /build
 COPY server/pom.xml .
 COPY server/src/ src/
-RUN ["mvn", "--no-transfer-progress", "package"]
+RUN ["mvn", "-ntp -DskipTests", "clean package"]
 
 FROM eclipse-temurin:23-jre
 WORKDIR /app


### PR DESCRIPTION
This pull request includes an update to the `docker/Dockerfile` to improve the build process by modifying the Maven command used during the build.

Build process improvement:

* [`docker/Dockerfile`](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL5-R5): Updated the Maven command to include `-ntp` (no transfer progress) and `-DskipTests` options, and changed the command from `package` to `clean package` to ensure a clean build.