### PR TITLE
Add skip tests to Dockerfile, fix typo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.9.9-eclipse-temurin-23 AS build
 WORKDIR /build
 COPY server/pom.xml .
 COPY server/src/ src/
-RUN ["mvn", "-ntp -DskipTests", "clean package"]
+RUN ["mvn", "-ntp", "clean", "package", "-DskipTests"]
 
 FROM eclipse-temurin:23-jre
 WORKDIR /app


### PR DESCRIPTION
This pull request includes a minor change to the `docker/Dockerfile`. The change modifies the `RUN` command to correctly pass the `-DskipTests` flag to the Maven build command.

* [`docker/Dockerfile`](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL5-R5): Updated the `RUN` command to properly format the Maven build command with the `-DskipTests` flag.