### PR TITLE
Fix main_build-and-push.yaml

### DIFF
--- a/.github/workflows/main_build-and-push.yaml
+++ b/.github/workflows/main_build-and-push.yaml
@@ -34,4 +34,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/prost_backend:${{ env.latest_version }}
-            ghcr.io/${{ github.repository_owner }}/prost_backend:$latest
+            ghcr.io/${{ github.repository_owner }}/prost_backend:latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/main_build-and-push.yaml` file. The change corrects the `tags` entry to properly reference the `latest` tag format.