### PR TITLE
Sync Main

### DIFF
--- a/.github/workflows/main_build-and-push.yaml
+++ b/.github/workflows/main_build-and-push.yaml
@@ -34,4 +34,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/prost_backend:${{ env.latest_version }}
-            ghcr.io/${{ github.repository_owner }}/prost_backend:$latest
+            ghcr.io/${{ github.repository_owner }}/prost_backend:latest

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.s-kuhn</groupId>
   <artifactId>prost</artifactId>
-  <version>0.0.6</version>
+  <version>0.0.7</version>
   <name>prost</name>
   <description>Manage provisioning for volunteer associations</description>
   <url>https://github.com/s-kuhn/PROST</url>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>edu.s-kuhn</groupId>
   <artifactId>prost</artifactId>
-  <version>0.0.7</version>
+  <version>0.0.8</version>
   <name>prost</name>
   <description>Manage provisioning for volunteer associations</description>
   <url>https://github.com/s-kuhn/PROST</url>


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/main_build-and-push.yaml` file. The change corrects the tag used for pushing the Docker image to the GitHub Container Registry.

* [`.github/workflows/main_build-and-push.yaml`](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0L37-R37): Fixed the Docker image tag to correctly use `latest` instead of `$latest`.