### PR TITLE
add checkout as compose was not found

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -118,6 +118,9 @@ jobs:
     if: ${{ github.event.pull_request.merged == true }}
 
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Copy Compose Files to Server
         uses: appleboy/scp-action@v0.1.5
         with:

--- a/.github/workflows/main_build-and-push.yaml
+++ b/.github/workflows/main_build-and-push.yaml
@@ -53,6 +53,9 @@ jobs:
     if: ${{ github.event.pull_request.merged == true }}
 
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Copy Compose Files to Server
         uses: appleboy/scp-action@v0.1.3
         with:

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Branch-conventions:
 
 - `main`: Contains stabile version for production.
 - `dev`: Contains features and bugfixes used for testing.
-  Versioning strategie:
+  Versioning strategies:
 - `MAJOR.MINOR.PATCH`:
     - **PATCH** is incremented for bugfixes.
     - **MINOR** is incremented for new features without breaking changes.


### PR DESCRIPTION
This pull request includes updates to GitHub Actions workflows and documentation improvements. The most important changes involve adding a repository checkout step to workflows and fixing a typo in the documentation.

### Workflow updates:
* [`.github/workflows/dev_build-and-push.yaml`](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0R121-R123): Added a step to check out the repository using `actions/checkout@v4` before copying Compose files to the server.
* [`.github/workflows/main_build-and-push.yaml`](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0R56-R58): Added a step to check out the repository using `actions/checkout@v4` before copying Compose files to the server.

### Documentation improvements:
* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L59-R59): Corrected a typo in the "Versioning strategies" section by fixing "strategies" from "strategie."