### PR TITLE
update actions in build workflows to latest versions

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Copy Compose Files to Server
-        uses: appleboy/scp-action@v0.1.5
+        uses: appleboy/scp-action@v1.0.0
         with:
           host: ${{ secrets.DEPLOY_SERVER_HOST }}
           username: ${{ secrets.DEPLOY_SERVER_USER }}
@@ -130,9 +130,11 @@ jobs:
           port: 22
           source: "docker/docker-compose.dev.yaml"
           target: ${{ secrets.DEPLOY_SERVER_PATH }}
+          strip_components: 1
+          overwrite: true
       
       - name: Deploy to server via SSH
-        uses: appleboy/ssh-action@v0.1.7
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.DEPLOY_SERVER_HOST }}
           username: ${{ secrets.DEPLOY_SERVER_USER }}

--- a/.github/workflows/main_build-and-push.yaml
+++ b/.github/workflows/main_build-and-push.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Copy Compose Files to Server
-        uses: appleboy/scp-action@v0.1.3
+        uses: appleboy/scp-action@v1.0.0
         with:
           host: ${{ secrets.DEPLOY_SERVER_HOST }}
           username: ${{ secrets.DEPLOY_SERVER_USER }}
@@ -65,9 +65,11 @@ jobs:
           port: 22
           source: "docker/docker-compose.prod.yaml"
           target: ${{ secrets.DEPLOY_SERVER_PATH }}
+          strip_components: 1
+          overwrite: true
 
       - name: Deploy to server via SSH
-        uses: appleboy/ssh-action@v0.1.7
+        uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.DEPLOY_SERVER_HOST }}
           username: ${{ secrets.DEPLOY_SERVER_USER }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use newer versions of the `appleboy/scp-action` and `appleboy/ssh-action` actions, along with additional configuration options for file copying. These changes improve compatibility, security, and functionality in deployment workflows.

### Workflow updates:

* **Updated `appleboy/scp-action` to version `v1.0.0`**: This change was applied in both `.github/workflows/dev_build-and-push.yaml` and `.github/workflows/main_build-and-push.yaml`. The new version includes support for additional options, such as `strip_components` and `overwrite`, which were added to streamline file handling during deployment. [[1]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L125-R137) [[2]](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0L60-R72)

* **Updated `appleboy/ssh-action` to version `v1.2.2`**: This ensures the use of a more recent and secure version of the SSH action in both workflows. [[1]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L125-R137) [[2]](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0L60-R72)