### PR TITLE
fix pipeline again

### DIFF
--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -69,7 +69,7 @@ jobs:
           git config user.email "actions@github.com"
           # Only create tag if it doesn't exist
           if ! git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
-            git tag -a "v${{ steps.get_version.outputs.version }}" -m "Backend version ${{ steps.get_version.outputs.version }} from PR #${{ github.event.pull_request.number }}"
+            git tag -a "v${{ steps.get_version.outputs.version }}" -m "Backend version ${{ steps.get_version.outputs.version }} (commit ${{ github.sha }})"
             git push origin "v${{ steps.get_version.outputs.version }}"
           else
             echo "Tag v${{ steps.get_version.outputs.version }} already exists, skipping tag creation"

--- a/.github/workflows/dev_build-and-push.yaml
+++ b/.github/workflows/dev_build-and-push.yaml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
       has_changes: ${{ needs.changes.outputs.backend }}
+      deploy_tag: ${{ steps.set_deploy_tag.outputs.tag }}
 
     steps:
       - name: Checkout code
@@ -50,13 +51,29 @@ jobs:
           echo "Current version from POM: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
+      - name: Set deployment tag
+        id: set_deploy_tag
+        run: |
+          if [ "${{ needs.changes.outputs.backend }}" == "true" ]; then
+            echo "tag=${{ steps.get_version.outputs.version }}" >> $GITHUB_OUTPUT
+            echo "Will use version tag: ${{ steps.get_version.outputs.version }}"
+          else
+            echo "tag=latest-dev" >> $GITHUB_OUTPUT
+            echo "Will use latest-dev tag (no changes detected)"
+          fi
+
       - name: Create Git Tag
         if: needs.changes.outputs.backend == 'true'
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git tag -a "v${{ steps.get_version.outputs.version }}" -m "Version ${{ steps.get_version.outputs.version }} from PR #${{ github.event.pull_request.number }}"
-          git push origin "v${{ steps.get_version.outputs.version }}"
+          # Only create tag if it doesn't exist
+          if ! git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+            git tag -a "v${{ steps.get_version.outputs.version }}" -m "Backend version ${{ steps.get_version.outputs.version }} from PR #${{ github.event.pull_request.number }}"
+            git push origin "v${{ steps.get_version.outputs.version }}"
+          else
+            echo "Tag v${{ steps.get_version.outputs.version }} already exists, skipping tag creation"
+          fi
 
       - name: Login to GitHub container registry
         uses: docker/login-action@v3
@@ -91,7 +108,7 @@ jobs:
           if [ "${{ needs.changes.outputs.backend }}" == "true" ]; then
             echo "Backend changes detected - new image built with version ${{ steps.get_version.outputs.version }}"
           else
-            echo "No backend changes - will use existing version ${{ steps.get_version.outputs.version }}"
+            echo "No backend changes - will use existing latest-dev image"
           fi
 
   # Build und Tag für Frontend
@@ -102,6 +119,7 @@ jobs:
     outputs:
       version: ${{ steps.get_version.outputs.version }}
       has_changes: ${{ needs.changes.outputs.frontend }}
+      deploy_tag: ${{ steps.set_deploy_tag.outputs.tag }}
 
     steps:
       - name: Checkout code
@@ -113,6 +131,17 @@ jobs:
           version=$(jq -r '.version' frontend/prost-frontend/package.json)
           echo "Current version from package.json: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Set deployment tag
+        id: set_deploy_tag
+        run: |
+          if [ "${{ needs.changes.outputs.frontend }}" == "true" ]; then
+            echo "tag=${{ steps.get_version.outputs.version }}" >> $GITHUB_OUTPUT
+            echo "Will use version tag: ${{ steps.get_version.outputs.version }}"
+          else
+            echo "tag=latest-dev" >> $GITHUB_OUTPUT
+            echo "Will use latest-dev tag (no changes detected)"
+          fi
 
       - name: Login to GitHub container registry
         uses: docker/login-action@v3
@@ -149,7 +178,7 @@ jobs:
           if [ "${{ needs.changes.outputs.frontend }}" == "true" ]; then
             echo "Frontend changes detected - new image built with version ${{ steps.get_version.outputs.version }}"
           else
-            echo "No frontend changes - will use existing version ${{ steps.get_version.outputs.version }}"
+            echo "No frontend changes - will use existing latest-dev image"
           fi
 
   deploy-dev:
@@ -158,13 +187,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     env:
-      VERSION_TAG_BACKEND: ${{ needs.build-and-tag-backend.outputs.version }}
-      VERSION_TAG_FRONTEND: ${{ needs.build-and-tag-frontend.outputs.version }}
+      VERSION_TAG_BACKEND: ${{ needs.build-and-tag-backend.outputs.deploy_tag }}
+      VERSION_TAG_FRONTEND: ${{ needs.build-and-tag-frontend.outputs.deploy_tag }}
 
     steps:
       - name: Log deployment info
         run: |
-          echo "Deploying with versions:"
+          echo "Deploying with tags:"
           echo "Backend: ${{ env.VERSION_TAG_BACKEND }} (Changes: ${{ needs.build-and-tag-backend.outputs.has_changes }})"
           echo "Frontend: ${{ env.VERSION_TAG_FRONTEND }} (Changes: ${{ needs.build-and-tag-frontend.outputs.has_changes }})"
 

--- a/.github/workflows/main_build-and-push.yaml
+++ b/.github/workflows/main_build-and-push.yaml
@@ -28,8 +28,8 @@ jobs:
         run: |
           git fetch origin dev --tags
           # Try to get latest tag, fallback to "latest" if no tags exist
-          latest_version=$(git tag -l "v*" | sort -V | tail -n 1 | sed 's/^v//' || echo "latest")
-          if [ -z "$latest_version" ] || [ "$latest_version" = "latest" ]; then
+          latest_version=$(git tag -l "v*" | sort -V | tail -n 1 | sed 's/^v//')
+          if [ -z "$latest_version" ]; then
             echo "No version tags found, using 'latest'"
             version_tag="latest"
           else

--- a/.github/workflows/main_build-and-push.yaml
+++ b/.github/workflows/main_build-and-push.yaml
@@ -14,10 +14,30 @@ jobs:
   sync-main:
     environment: prod
     runs-on: ubuntu-latest
+    outputs:
+      version_tag: ${{ steps.get_version.outputs.version }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version for production
+        id: get_version
+        run: |
+          git fetch origin dev --tags
+          # Try to get latest tag, fallback to "latest" if no tags exist
+          latest_version=$(git tag -l "v*" | sort -V | tail -n 1 | sed 's/^v//' || echo "latest")
+          if [ -z "$latest_version" ] || [ "$latest_version" = "latest" ]; then
+            echo "No version tags found, using 'latest'"
+            version_tag="latest"
+          else
+            echo "Found latest version: $latest_version"
+            version_tag="$latest_version"
+          fi
+          echo "version=$version_tag" >> $GITHUB_OUTPUT
+          echo "Will deploy with version: $version_tag"
 
       - name: Login to GitHub container registry
         uses: docker/login-action@v3
@@ -25,12 +45,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_TOKEN }}
-
-      - name: Fetch latest tag from dev
-        run: |
-          git fetch origin dev --tags
-          latest_version=$(git tag -l | sort -V | tail -n 1)
-          echo "latest_version=$latest_version" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -49,7 +63,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/prost_backend:${{ env.latest_version }}
+            ghcr.io/${{ github.repository_owner }}/prost_backend:${{ steps.get_version.outputs.version }}
             ghcr.io/${{ github.repository_owner }}/prost_backend:latest
 
       - name: Build and push Frontend
@@ -60,7 +74,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/prost_frontend:${{ env.latest_version }}
+            ghcr.io/${{ github.repository_owner }}/prost_frontend:${{ steps.get_version.outputs.version }}
             ghcr.io/${{ github.repository_owner }}/prost_frontend:latest
           build-args: |
             BUILD_CONFIGURATION=prod
@@ -72,6 +86,10 @@ jobs:
     if: ${{ github.event.pull_request.merged == true }}
 
     steps:
+      - name: Log deployment info
+        run: |
+          echo "Deploying production with version: ${{ needs.sync-main.outputs.version_tag }}"
+
       - name: Checkout repo
         uses: actions/checkout@v4
 
@@ -115,7 +133,7 @@ jobs:
             cd ${{ secrets.DEPLOY_SERVER_PATH }}
             docker image prune -a --force
             cat > docker/.env <<EOF
-            VERSION_TAG=${{ secrets.VERSION_TAG }}
+            VERSION_TAG=${{ needs.sync-main.outputs.version_tag }}
             GH_REPOSITORY_OWNER=${{ secrets.GH_REPOSITORY_OWNER }}
             POSTGRES_USER=${{ secrets.POSTGRES_USER }}
             POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}

--- a/frontend/prost-frontend/docker-entrypoint.sh
+++ b/frontend/prost-frontend/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Set default values if not provided
 export BACKEND_HOSTNAME=${BACKEND_HOSTNAME:-backend}
-export KEYCLOAK_HOSTNAME=${KEYCLOAK_HOSTNAME:-localhost}
+export KEYCLOAK_HOSTNAME=${KEYCLOAK_HOSTNAME:-localhost:8081}
 export FRONTEND_HOSTNAME=${FRONTEND_HOSTNAME:-localhost:80}
 
 # Generate nginx.conf from template

--- a/frontend/prost-frontend/nginx.conf.template
+++ b/frontend/prost-frontend/nginx.conf.template
@@ -34,7 +34,7 @@ http {
     }
 
     upstream keycloak {
-        server ${KEYCLOAK_HOSTNAME}:8081;
+        server ${KEYCLOAK_HOSTNAME};
     }
 
     server {


### PR DESCRIPTION
This pull request updates the CI/CD workflows for both development and production environments, improving how deployment tags are set and used. The changes ensure that images are tagged appropriately based on whether there are backend or frontend changes, and streamline the process of determining which image version to deploy. Additionally, there are small improvements to the frontend container configuration for consistency.

**CI/CD workflow improvements**

* Added logic to set a deployment tag (`deploy_tag`) in both backend and frontend build jobs: uses the version if there are changes, otherwise defaults to `latest-dev`. This tag is passed to the deploy job, ensuring deployments use the correct image version. (.github/workflows/dev_build-and-push.yaml: [[1]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0R39) [[2]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0R54-R76) [[3]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0R122) [[4]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0R135-R145) [[5]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L161-R196)
* Updated deployment logs and environment variables to reference deployment tags instead of just versions, making it clearer which image is being used for deployment. (.github/workflows/dev_build-and-push.yaml: [[1]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L94-R111) [[2]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L152-R181) [[3]](diffhunk://#diff-1d4574795146d0bf4e563470350247b30da7e36e59b724b354ceee5d3d94fbb0L161-R196)
* Improved production workflow to fetch and use the latest version tag from the `dev` branch for both backend and frontend images, and to pass this tag through the deployment steps. (.github/workflows/main_build-and-push.yaml: [[1]](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0R17-R40) [[2]](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0L29-L34) [[3]](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0L52-R66) [[4]](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0L63-R77) [[5]](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0R89-R92) [[6]](diffhunk://#diff-db6ec69255882e383cb657e8fec7e089538ead696332a30e3e04f7ce744c43d0L118-R136)

**Frontend container configuration**

* Changed default `KEYCLOAK_HOSTNAME` to include the port (`localhost:8081`) for consistency in the frontend entrypoint script, and updated nginx configuration to use the full hostname variable. (frontend/prost-frontend/docker-entrypoint.sh: [[1]](diffhunk://#diff-8655ff8a81766651d27b5e99a4cc3efd90ed15d1caa0bb7040ee8ecc2122be29L5-R5) frontend/prost-frontend/nginx.conf.template: [[2]](diffhunk://#diff-53b0d960ea8434daf0f3f3a0e3a335039810a12bb26c13e75c640b4969305f92L37-R37)